### PR TITLE
remove concurrent ruby dep from gemspec template

### DIFF
--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -31,7 +31,6 @@
 
     s.add_dependency 'google-protobuf', '~> 3.0.2'
     s.add_dependency 'googleauth',      '~> 0.5.1'
-    s.add_dependency 'concurrent-ruby'
 
     s.add_development_dependency 'bundler',            '~> 1.9'
     s.add_development_dependency 'facter',             '~> 2.4'


### PR DESCRIPTION
I left out one more thing related to the thread pool change - since this dependency is getting removed by the fixed thread pool in v1.0.x, need to get rid of it from the template too.