### PR TITLE
Remove calls to optional parameters so that the test is compatible wi…

### DIFF
--- a/src/ruby/end2end/grpc_class_init_client.rb
+++ b/src/ruby/end2end/grpc_class_init_client.rb
@@ -41,7 +41,7 @@ def run_gc_stress_test(test_proc)
   GC.enable
   construct_many(test_proc)
 
-  GC.start(full_mark: true, immediate_sweep: true)
+  GC.start
   construct_many(test_proc)
 end
 


### PR DESCRIPTION
…th ruby versions < 2.1


From repro'ing that error and the ruby docs, it looks like the `full_mark` and `immediate_sweep` params are only available in ruby 2.1+.

Since ruby 2..0+ are supported, I think it makes sense to make the test compatible with ruby 2.0.

One hesitation though: it looks like the ruby version on mac right now is less than 2.1? I think this can be ok, but a heads up that the ruby version on jenkins mac is 2.4 (2.4 ruby AFAIR is needed to publish ruby-2.4-and-downwards-compatible mac gems, which could be an issue if something like the artifact build is moved to kokoro).