### PR TITLE
Towards cares upgrade with mingw

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,8 +84,9 @@ task 'dlls' do
   env += 'LDFLAGS=-static '
   env += 'SYSTEM=MINGW32 '
   env += 'EMBED_ZLIB=true '
-  env += 'BUILDDIR=/tmp '
   env += 'EMBED_OPENSSL=true '
+  env += 'EMBED_CARES=true '
+  env += 'BUILDDIR=/tmp '
   env += "V=#{verbose} "
   out = GrpcBuildConfig::CORE_WINDOWS_DLL
 

--- a/Rakefile
+++ b/Rakefile
@@ -85,6 +85,7 @@ task 'dlls' do
   env += 'SYSTEM=MINGW32 '
   env += 'EMBED_ZLIB=true '
   env += 'BUILDDIR=/tmp '
+  env += 'EMBED_OPENSSL=true '
   env += "V=#{verbose} "
   out = GrpcBuildConfig::CORE_WINDOWS_DLL
 

--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,7 @@ task 'dlls' do
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   verbose = ENV['V'] || '0'
 
-  env = 'CPPFLAGS="-D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -Wno-unused-variable -Wno-unused-result -DCARES_STATICLIB" '
+  env = 'CPPFLAGS="-D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -Wno-unused-variable -Wno-unused-result -DCARES_STATICLIB -Wno-error=conversion -Wno-incompatible-pointer-types -Wno-sign-compare -Wno-parentheses" '
   env += 'LDFLAGS=-static '
   env += 'SYSTEM=MINGW32 '
   env += 'EMBED_ZLIB=true '

--- a/third_party/cares/ares_build.h
+++ b/third_party/cares/ares_build.h
@@ -192,8 +192,13 @@
 #endif
 
 /* Data type definition of ares_ssize_t. */
+/* gRPC Manuel edit here!
+ * Possibly include <_mingw.h> header to define __int64 type under mingw */
 #ifdef _WIN32
 #  ifdef _WIN64
+#    ifdef __MINGW32__
+#      include <_mingw.h>
+#    endif
 #    define CARES_TYPEOF_ARES_SSIZE_T __int64
 #  else
 #    define CARES_TYPEOF_ARES_SSIZE_T long

--- a/third_party/rake-compiler-dock/Dockerfile
+++ b/third_party/rake-compiler-dock/Dockerfile
@@ -205,6 +205,5 @@ RUN echo '!<arch>' > /usr/local/rake-compiler/ruby/i686-linux-gnu/ruby-2.4.0/lib
 ENV RUBY_CC_VERSION 2.4.0:2.3.0:2.2.2:2.1.5:2.0.0
 
 RUN apt-get install -y g++-multilib
-RUN apt-get install -y libssl-dev
 
 CMD bash

--- a/third_party/rake-compiler-dock/Dockerfile
+++ b/third_party/rake-compiler-dock/Dockerfile
@@ -1,21 +1,16 @@
-FROM ubuntu:14.04
+FROM ubuntu:17.04
 
 RUN apt-get -y update && \
-    apt-get install -y curl git-core mingw-w64 xz-utils build-essential gcc-multilib wget unzip
-
-RUN mkdir -p /opt/mingw && \
-    curl -SL http://downloads.sourceforge.net/mingw-w64/i686-w64-mingw32-gcc-4.7.2-release-linux64_rubenvb.tar.xz | \
-    tar -xJC /opt/mingw && \
-    echo "export PATH=\$PATH:/opt/mingw/mingw32/bin" >> /etc/rubybashrc
-
-RUN mkdir -p /opt/mingw && \
-    curl -SL http://downloads.sourceforge.net/mingw-w64/x86_64-w64-mingw32-gcc-4.7.2-release-linux64_rubenvb.tar.xz | \
-    tar -xJC /opt/mingw && \
-    echo "export PATH=\$PATH:/opt/mingw/mingw64/bin" >> /etc/rubybashrc
+    apt-get install -y curl git-core xz-utils build-essential wget unzip sudo gpg dirmngr
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000
 RUN groupadd -r rvm && useradd -r -g rvm -G sudo -p "" --create-home rvm && \
     echo "source /etc/profile.d/rvm.sh" >> /etc/rubybashrc
+
+USER root
+RUN apt-get -y update && \
+    apt-get install -y gcc-mingw-w64-x86-64 gcc-mingw-w64-i686 g++-mingw-w64-x86-64 g++-mingw-w64-i686 \
+        gcc-multilib moreutils
 USER rvm
 
 # install rvm, RVM 1.26.0+ has signed releases, source rvm for usage outside of package scripts
@@ -178,12 +173,8 @@ RUN sed -i -- "s:/root/.rake-compiler:/usr/local/rake-compiler:g" /usr/local/rak
 # Install wrappers for strip commands as a workaround for "Protocol error" in boot2docker.
 RUN cp /tmp/build/strip_wrapper /root/
 RUN sudo chmod +rx /root/strip_wrapper
-RUN mv /opt/mingw/mingw32/bin/i686-w64-mingw32-strip /opt/mingw/mingw32/bin/i686-w64-mingw32-strip.bin && \
-    mv /opt/mingw/mingw64/bin/x86_64-w64-mingw32-strip /opt/mingw/mingw64/bin/x86_64-w64-mingw32-strip.bin && \
-    mv /usr/bin/i686-w64-mingw32-strip /usr/bin/i686-w64-mingw32-strip.bin && \
+RUN mv /usr/bin/i686-w64-mingw32-strip /usr/bin/i686-w64-mingw32-strip.bin && \
     mv /usr/bin/x86_64-w64-mingw32-strip /usr/bin/x86_64-w64-mingw32-strip.bin && \
-    ln /root/strip_wrapper /opt/mingw/mingw32/bin/i686-w64-mingw32-strip && \
-    ln /root/strip_wrapper /opt/mingw/mingw64/bin/x86_64-w64-mingw32-strip && \
     ln /root/strip_wrapper /usr/bin/i686-w64-mingw32-strip && \
     ln /root/strip_wrapper /usr/bin/x86_64-w64-mingw32-strip
 
@@ -214,5 +205,6 @@ RUN echo '!<arch>' > /usr/local/rake-compiler/ruby/i686-linux-gnu/ruby-2.4.0/lib
 ENV RUBY_CC_VERSION 2.4.0:2.3.0:2.2.2:2.1.5:2.0.0
 
 RUN apt-get install -y g++-multilib
+RUN apt-get install -y libssl-dev
 
 CMD bash


### PR DESCRIPTION
This is getting closer but is a work in progress since I haven't successfully built the ruby artifacts yet.

Docker file updates updates mingw/gcc to 6.2.

This still needs some compiler warnings turned off and ability to find openssl headers.

now failing with:

```
compilation terminated.
Makefile:2523: recipe for target '/tmp/objs/opt/src/core/lib/security/credentials/jwt/jwt_verifier.o' failed
make: *** [/tmp/objs/opt/src/core/lib/security/credentials/jwt/jwt_verifier.o] Error 1
In file included from ./src/core/lib/security/credentials/jwt/jwt_credentials.h:23:0,
                 from src/core/lib/security/credentials/google_default/google_default_credentials.c:31:
./src/core/lib/security/credentials/jwt/json_token.h:23:25: fatal error: openssl/rsa.h: No such file or directory
 #include <openssl/rsa.h>
                         ^
compilation terminated.
Makefile:2523: recipe for target '/tmp/objs/opt/src/core/lib/security/credentials/google_default/google_default_credentials.o' failed
make: *** [/tmp/objs/opt/src/core/lib/security/credentials/google_default/google_default_credentials.o] Error 1
src/core/tsi/ssl_transport_security.c:42:25: fatal error: openssl/bio.h: No such file or directory
 #include <openssl/bio.h>
                         ^
compilation terminated.
Makefile:2523: recipe for target '/tmp/objs/opt/src/core/tsi/ssl_transport_security.o' failed
make: *** [/tmp/objs/opt/src/core/tsi/ssl_transport_security.o] Error 1
third_party/cares/cares/ares_process.c: In function 'socket_recvfrom':
third_party/cares/cares/ares_process.c:339:29: error: conversion to 'int' from 'size_t {aka long long unsigned int}' may alter its value [-Werror=conversion]
    return recvfrom(s, data, data_len, flags, from, from_len);
                             ^~~~~~~~
cc1: all warnings being treated as errors
Makefile:2523: recipe for target '/tmp/objs/opt/third_party/cares/cares/ares_process.o' failed
make: *** [/tmp/objs/opt/third_party/cares/cares/ares_process.o] Error 1
third_party/cares/cares/ares_init.c: In function 'contains_suffix':
third_party/cares/cares/ares_init.c:1339:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if (len == (end - beg) && !strnicmp(beg, suffix, len))
             ^~
third_party/cares/cares/ares_init.c: In function 'get_SuffixList_Windows':
third_party/cares/cares/ares_init.c:1430:32: error: passing argument 1 of 'next_suffix' from incompatible pointer type [-Werror=incompatible-pointer-types]
       while (len = next_suffix(&pp, len))
                                ^
third_party/cares/cares/ares_init.c:1347:15: note: expected 'const char **' but argument is of type 'char **'
 static size_t next_suffix(const char** list, const size_t advance)
               ^~~~~~~~~~~
third_party/cares/cares/ares_init.c:1430:7: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
       while (len = next_suffix(&pp, len))
```

