### PR TITLE
AWS integration: add test jobs for multiple languages.

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_aws_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_basictests_csharp.cfg
@@ -1,0 +1,36 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
+timeout_mins: 90
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 73836
+            keyname: "grpc_aws_ec2_credentials"
+        }
+    }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+  }
+}
+env_vars {
+  key: "REMOTE_WORKLOAD_SCRIPT"
+  value: "tools/internal_ci/linux/aws/grpc_run_basictests_csharp_aarch64.sh"
+}

--- a/tools/internal_ci/linux/aws/grpc_aws_basictests_php.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_basictests_php.cfg
@@ -1,0 +1,36 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
+timeout_mins: 90
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 73836
+            keyname: "grpc_aws_ec2_credentials"
+        }
+    }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+  }
+}
+env_vars {
+  key: "REMOTE_WORKLOAD_SCRIPT"
+  value: "tools/internal_ci/linux/aws/grpc_run_basictests_php_aarch64.sh"
+}

--- a/tools/internal_ci/linux/aws/grpc_aws_basictests_python.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_basictests_python.cfg
@@ -1,0 +1,36 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
+timeout_mins: 90
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 73836
+            keyname: "grpc_aws_ec2_credentials"
+        }
+    }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+  }
+}
+env_vars {
+  key: "REMOTE_WORKLOAD_SCRIPT"
+  value: "tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh"
+}

--- a/tools/internal_ci/linux/aws/grpc_aws_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_basictests_ruby.cfg
@@ -1,0 +1,36 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
+timeout_mins: 90
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 73836
+            keyname: "grpc_aws_ec2_credentials"
+        }
+    }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+  }
+}
+env_vars {
+  key: "REMOTE_WORKLOAD_SCRIPT"
+  value: "tools/internal_ci/linux/aws/grpc_run_basictests_ruby_aarch64.sh"
+}

--- a/tools/internal_ci/linux/aws/grpc_aws_bazel_test_c_cpp.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_bazel_test_c_cpp.cfg
@@ -1,0 +1,36 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
+timeout_mins: 90
+before_action {
+    fetch_keystore {
+        keystore_resource {
+            keystore_config_id: 73836
+            keyname: "grpc_aws_ec2_credentials"
+        }
+    }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+  }
+}
+env_vars {
+  key: "REMOTE_WORKLOAD_SCRIPT"
+  value: "tools/internal_ci/linux/aws/grpc_bazel_test_c_cpp_aarch64.sh"
+}

--- a/tools/internal_ci/linux/aws/grpc_aws_experiment.cfg
+++ b/tools/internal_ci/linux/aws/grpc_aws_experiment.cfg
@@ -15,7 +15,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_experiment.sh"
+build_file: "grpc/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh"
 timeout_mins: 90
 before_action {
     fetch_keystore {

--- a/tools/internal_ci/linux/aws/grpc_bazel_test_c_cpp_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_bazel_test_c_cpp_aarch64.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python python-pip clang
+sudo pip install six
+
+cd grpc
+
+# tests require port server to be running
+python tools/run_tests/start_port_server.py
+
+# test gRPC C/C++ with bazel
+tools/bazel test --config=opt --test_output=errors --test_tag_filters=-no_linux --build_tag_filters=-no_linux --flaky_test_attempts=1 --runs_per_test=1 //test/...

--- a/tools/internal_ci/linux/aws/grpc_run_basictests_csharp_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_csharp_aarch64.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python python-pip clang
+sudo pip install six
+
+# install gRPC C# pre-requisites
+curl -sSL -o dotnet-install.sh https://dot.net/v1/dotnet-install.sh
+chmod u+x dotnet-install.sh
+./dotnet-install.sh --channel 2.1  # needed for the netcoreapp2.1 targets
+./dotnet-install.sh --channel 5.0
+export PATH="$HOME/.dotnet:$PATH"
+
+# Disable some unwanted dotnet options
+export NUGET_XMLDOC_MODE=skip
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+export DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+dotnet --list-sdks
+
+cd grpc
+
+git submodule update --init
+
+# build and test C#
+tools/run_tests/run_tests.py -l csharp -c opt --compiler coreclr -t -x run_tests/csharp_linux_aarch64_opt_native/sponge_log.xml --report_suite_name csharp_linux_aarch64_opt_native --report_multi_target

--- a/tools/internal_ci/linux/aws/grpc_run_basictests_php_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_php_aarch64.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python python-pip clang
+sudo pip install six
+
+# install gRPC Ruby pre-requisites
+sudo apt install -y php7.2-cli php7.2-dev
+sudo apt install -y composer phpunit
+sudo apt install -y php-bcmath  # required by protobuf PHP, is it really needed for gRPC?
+
+cd grpc
+
+git submodule update --init
+
+# build and test php
+tools/run_tests/run_tests.py -l php7 -c opt -t -x run_tests/php7_linux_aarch64_opt_native/sponge_log.xml --report_suite_name php7_linux_aarch64_opt_native --report_multi_target

--- a/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python python-pip clang
+sudo pip install six
+
+# install python3.6 and pip
+sudo apt install -y python3 python3-pip
+python3 --version
+
+cd grpc
+
+git submodule update --init
+
+# build and test python (currently we only test with python3.6, but that's ok since our aarch64 testing resources are limited)
+tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform native -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
+tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform asyncio -t -x run_tests/python_linux_opt_gevent/sponge_log.xml --report_suite_name python_linux_opt_asyncio --report_multi_target || FAILED=true
+tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform gevent -t -x run_tests/python_linux_opt_gevent/sponge_log.xml --report_suite_name python_linux_opt_gevent --report_multi_target || FAILED=true
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi

--- a/tools/internal_ci/linux/aws/grpc_run_basictests_ruby_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_ruby_aarch64.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python python-pip clang
+sudo pip install six
+
+# install gRPC Ruby pre-requisites
+sudo apt install -y ruby ruby-dev
+sudo gem install bundler
+ruby --version
+
+cd grpc
+
+git submodule update --init
+
+# build and test ruby
+tools/run_tests/run_tests.py -l ruby -c opt -t -x run_tests/ruby_linux_aarch64_opt_native/sponge_log.xml --report_suite_name ruby_linux_aarch64_opt_native --report_multi_target


### PR DESCRIPTION
C/C++ (with bazel), C#, python, php, ruby.

the remote test script for each of the languages aren't that interesting (it's just installing prerequisites and running build & test), but there are a few (mostly minor) changes to the script that drives the remote execution.
